### PR TITLE
Add margin before Download button in plugin header

### DIFF
--- a/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
+++ b/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/client/components/plugin/style.scss
@@ -12,7 +12,7 @@
 
 		.plugin-actions {
 			float: right;
-
+			margin-inline-start: 1rem;
 			div {
 				display: inline-block;
 				text-align: center;


### PR DESCRIPTION
Hallo, this is a tiny fix for something that has been bothering me. When the Plugin title is a bit long on desktop, it bumps right into the `Download` button like so:
<img width="1115" alt="Screen Shot 2022-06-02 at 4 43 15 PM" src="https://user-images.githubusercontent.com/6925260/171750188-a0efc08b-6c22-459b-8181-b9ec7813bc96.png">

I've added a little margin (to match the margin between the thumbnail and title) so this doesn't happen:

<img width="1076" alt="Screen Shot 2022-06-02 at 4 43 46 PM" src="https://user-images.githubusercontent.com/6925260/171750232-529315fb-5bea-4d65-bc63-b397dfb5d00f.png">


I haven't rebuilt the style files yet, but if this change is okay, do let me know and I'll look up the docs to build the files and stuff. :)

